### PR TITLE
#21 1.Rate limit for authenticated user and anonymous user

### DIFF
--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -44,4 +44,6 @@ DGA-U: Errors raised at the utilities level (utils.py)
 | DGA-S008   | Save(Update)    | User Error! The ID is invalid.                                                            |
 | DGA-S009   | Save            | User Error! The user has included an extra field in saveInput.                            |
 | DGA-U001   | Field search    | User Error! Field not found.                                                              |
+| DGA-U002   | Field search    | User Error! An extra field has been passed by the user.                                   |
+| DGA-U003   | Request Limit   | User Error! The user has exceeded the request limit.                                      |
  

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -45,5 +45,5 @@ DGA-U: Errors raised at the utilities level (utils.py)
 | DGA-S009   | Save            | User Error! The user has included an extra field in saveInput.                            |
 | DGA-U001   | Field search    | User Error! Field not found.                                                              |
 | DGA-U002   | Field search    | User Error! An extra field has been passed by the user.                                   |
-| DGA-U003   | Request Limit   | User Error! The user has exceeded the request limit.                                      |
+| DGA-U003   | Request Rate    | User Error! The user has exceeded the request rate.                                       |
  

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = "shrijancstech@gmail.com"  # Your Gmail address
+EMAIL_HOST_USER = "user@example.com"  # Your Gmail address
 EMAIL_HOST_PASSWORD = "srcp yqyu xteg nzfe"  # Your Gmail password
 ```
 
@@ -150,6 +150,32 @@ path("<url prefix>", include('django_generic_api.urls'))
 
 ---
 
+### Limiting User Requests
+
+- This package allows you to limit the number of requests that can be sent within a specified time period. 
+- The default request limits are set as follows:
+```bash
+  Authenticated users: 2000 requests per 1 hour
+  Anonymous users: 20 requests per 1 hour
+```
+- To customize these default settings, add the following to settings.py:
+```bash
+# Set 'user' for authenticated users
+# Set 'anon' for unauthenticated users
+
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle'
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '.../day',
+        'user': '.../day'
+    }
+}
+```
+
+---
 # Parameters for requests
 
 - This API supports both session-based and token-based authentication.

--- a/django_generic_api/__init__.py
+++ b/django_generic_api/__init__.py
@@ -1,0 +1,3 @@
+# django_generic_api/__init__.py
+
+default_app_config = "django_generic_api.apps.DjangoGenericApiConfig"

--- a/django_generic_api/apps.py
+++ b/django_generic_api/apps.py
@@ -14,14 +14,16 @@ class DjangoGenericApiConfig(AppConfig):
         DEFAULT_DRF_THROTTLE_SETTINGS = {
             "DEFAULT_THROTTLE_CLASSES": [
                 # Customized anon user
-                "django_generic_api.utils.ExtendedRateThrottle",
+                "rest_framework.throttling.AnonRateThrottle",
                 # DRF authenticated user
                 "rest_framework.throttling.UserRateThrottle",
             ],
             "DEFAULT_THROTTLE_RATES": {
-                "user": "100/minute",  # Rate limit for authenticated users
-                "anon": "5/10m",  # Rate limit for unauthenticated users 5, request per 10 minutes
+                "user": "2000/hour",  # Rate limit for authenticated users
+                "anon": "20/hour",  # Rate limit for unauthenticated users,
+                # 20 request per 1 hour
             },
+            "EXCEPTION_HANDLER": "django_generic_api.utils.custom_exception_handler",
         }
 
         # Apply these defaults directly to `REST_FRAMEWORK` settings

--- a/django_generic_api/apps.py
+++ b/django_generic_api/apps.py
@@ -1,0 +1,34 @@
+# django_generic_api/apps.py
+
+from django.apps import AppConfig
+from django.conf import settings
+from rest_framework.settings import api_settings
+
+
+class DjangoGenericApiConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "django_generic_api"
+
+    def ready(self):
+        # Predefining the DRF throttle settings
+        DEFAULT_DRF_THROTTLE_SETTINGS = {
+            "DEFAULT_THROTTLE_CLASSES": [
+                # Customized anon user
+                "django_generic_api.utils.ExtendedRateThrottle",
+                # DRF authenticated user
+                "rest_framework.throttling.UserRateThrottle",
+            ],
+            "DEFAULT_THROTTLE_RATES": {
+                "user": "100/minute",  # Rate limit for authenticated users
+                "anon": "5/10m",  # Rate limit for unauthenticated users 5, request per 10 minutes
+            },
+        }
+
+        # Apply these defaults directly to `REST_FRAMEWORK` settings
+        if not hasattr(settings, "REST_FRAMEWORK"):
+            settings.REST_FRAMEWORK = {}
+
+        # Apply these defaults directly to `api_settings`
+        for key, value in DEFAULT_DRF_THROTTLE_SETTINGS.items():
+            if key not in settings.REST_FRAMEWORK:
+                settings.REST_FRAMEWORK[key] = value

--- a/django_generic_api/utils.py
+++ b/django_generic_api/utils.py
@@ -153,7 +153,7 @@ def custom_exception_handler(exc, context):
     if isinstance(exc, Throttled):
         response = Response(
             {
-                "error": "Too many requests. Please wait for sometime.",
+                "error": "Too many requests. Please try after sometime.",
                 "code": "DGA-U003",
             },
             status=exc.status_code,

--- a/django_generic_api/views.py
+++ b/django_generic_api/views.py
@@ -11,11 +11,6 @@ from pydantic import ValidationError
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.throttling import (
-    BaseThrottle,
-    UserRateThrottle,
-    AnonRateThrottle,
-)
 from .payload_models import (
     FetchPayload,
     SavePayload,
@@ -30,7 +25,6 @@ from .services import (
     generate_token,
 )
 from .utils import (
-    ExtendedRateThrottle,
     make_permission_str,
     registration_token,
     store_user_ip,
@@ -38,7 +32,6 @@ from .utils import (
 
 
 class GenericSaveAPIView(APIView):
-    throttle_classes = [UserRateThrottle]
 
     @method_decorator(validate_access_token)
     def dispatch(self, *args, **kwargs):
@@ -108,7 +101,6 @@ class GenericSaveAPIView(APIView):
 
 
 class GenericFetchAPIView(APIView):
-    throttle_classes = [UserRateThrottle]
 
     # authenticates user by token
     @method_decorator(validate_access_token)
@@ -177,7 +169,6 @@ class GenericFetchAPIView(APIView):
 
 
 class GenericLoginAPIView(APIView):
-    throttle_classes = [ExtendedRateThrottle]
 
     def post(self, *args, **kwargs):
         payload = self.request.data.get("payload", {}).get("variables", {})
@@ -229,7 +220,6 @@ class GenericLoginAPIView(APIView):
 
 
 class GenericRegisterAPIView(APIView):
-    throttle_classes = [ExtendedRateThrottle]
 
     def post(self, *args, **kwargs):
         payload = self.request.data.get("payload", {}).get("variables", {})
@@ -302,7 +292,6 @@ class GenericRegisterAPIView(APIView):
 
 
 class GenericForgotPasswordAPIView(APIView):
-    throttle_classes = [ExtendedRateThrottle]
 
     def post(self, *args, **kwargs):
         payload = self.request.data.get("payload", {}).get("variables", {})
@@ -316,7 +305,6 @@ class GenericForgotPasswordAPIView(APIView):
 
 
 class LogoutAPIView(APIView):
-    throttle_classes = [UserRateThrottle]
 
     def post(self, *args, **kwargs):
         logout(self.request)
@@ -326,7 +314,6 @@ class LogoutAPIView(APIView):
 
 
 class AccountActivateAPIView(APIView):
-    throttle_classes = [ExtendedRateThrottle]
 
     def get(self, request, encoded_token, *args, **kwargs):
         try:


### PR DESCRIPTION
- Initiated rate limiting by DRF throttling for authenticated and anonymous user.
- Raises 429 error if predefined limit exceeds