### PR TITLE
BASE_URL for SMTP settings.

### DIFF
--- a/django_generic_api/views.py
+++ b/django_generic_api/views.py
@@ -252,6 +252,12 @@ class GenericRegisterAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        if not getattr(settings, 'BASE_URL', None):
+            return Response(
+                {"error": "Configure BASE_URL before registration.", "code": "DGA-V023"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         user = User.objects.filter(username=email).exists()
         if user:
             return Response(


### PR DESCRIPTION
- Raises error if base_url is not set for registration.